### PR TITLE
add <stdexcept> header

### DIFF
--- a/contrib/ClickHouseHashTable/Allocator.h
+++ b/contrib/ClickHouseHashTable/Allocator.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include <cstring>
+#include <stdexcept>
 
 template <bool clear_memory_, bool mmap_populate = false>
 class Allocator;


### PR DESCRIPTION
```
In file included from /home/user/git/hash-table-aggregation-benchmark/contrib/ClickHouseHashTable/Allocator.cpp:1:
/home/user/git/hash-table-aggregation-benchmark/contrib/ClickHouseHashTable/Allocator.h:239:28: error: no member named 'runtime_error' in namespace 'std'
                throw std::runtime_error("Allocator: Cannot realloc");
                      ~~~~~^
```